### PR TITLE
Device should be casted as clientObject after discovery

### DIFF
--- a/lib/discoverer.js
+++ b/lib/discoverer.js
@@ -83,7 +83,7 @@ function setTimeoutPromise(millis) {
 function discoverCastDevices(discoveryTimeMillis = DEFAULT_DISCOVER_TIME_MILLIS) {
     queryCastDevices();
 
-    return setTimeoutPromise(discoveryTimeMillis).then(deviceState.getAllDevices);
+    return setTimeoutPromise(discoveryTimeMillis).then(getDiscoveredCastDevices);
 }
 
 function getDiscoveredCastDevices() {


### PR DESCRIPTION
Hi!
I have tried your chromecast driver today and I always had an error on the device discovery step in Neeo UI.
After some debugging it seems that you forgot to cast the discovered cast devices to the underlying clientObject needed for the next steps.

I've made the small correction :)